### PR TITLE
Adding fallback mechanism

### DIFF
--- a/src/Stencil.php
+++ b/src/Stencil.php
@@ -5,10 +5,21 @@ namespace Minicli;
 class Stencil
 {
     public string $stencilDir;
+    public array $fallbackDirs = [];
 
     public function __construct(string $stencilDir)
     {
         $this->stencilDir = $stencilDir;
+    }
+
+    /**
+     * Additional template dirs to look for
+     * @param array $fallbackDirs
+     * @return void
+     */
+    public function fallbackTo(array $fallbackDirs)
+    {
+        $this->fallbackDirs = $fallbackDirs;
     }
 
     /**
@@ -46,9 +57,21 @@ class Stencil
         $templateFile = $this->stencilDir . '/' . $template . '.tpl';
 
         if (!is_file($templateFile)) {
-            throw new FileNotFoundException("Template file not found.");
+            $templateFile = $this->locateFallbackTemplate($template);
         }
 
         return file_get_contents($templateFile);
+    }
+
+    public function locateFallbackTemplate(string $template): string
+    {
+        foreach ($this->fallbackDirs as $fallbackDir) {
+            $templateFile = $fallbackDir . '/' . $template . '.tpl';
+            if (is_file($templateFile)) {
+                return $templateFile;
+            }
+        }
+
+        throw new FileNotFoundException("Template file not found.");
     }
 }

--- a/tests/Assets/Fallback/othertemplate.tpl
+++ b/tests/Assets/Fallback/othertemplate.tpl
@@ -1,0 +1,3 @@
+## This is my Other Template
+
+My name is {{ name }} and I am a {{ description }}.

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,5 +43,7 @@ expect()->extend('toContain', function (string $string) {
 
 function getStencil(): Stencil
 {
-    return new Stencil(__DIR__ . '/Assets');
+    $stencil = new Stencil(__DIR__ . '/Assets');
+    $stencil->fallbackTo([__DIR__ . '/Assets/Fallback']);
+    return $stencil;
 }

--- a/tests/StencilTest.php
+++ b/tests/StencilTest.php
@@ -1,13 +1,22 @@
 <?php
 
+use Minicli\FileNotFoundException;
+
 it('sets the template dir', function () {
     $stencil = getStencil();
     expect($stencil->stencilDir)->toBeString();
 });
 
+it('falls back to secondary tpl dir when tpl not found in default location', function () {
+    $stencil = getStencil();
+    $parsedContent = $stencil->applyTemplate('othertemplate', []);
+    expect($parsedContent)->toBeString();
+    $this->assertStringContainsString("This is my Other Template", $parsedContent);
+});
+
 it('throws exception if template not found', function () {
     $stencil = getStencil();
-    $this->expectException(\Minicli\FileNotFoundException::class);
+    $this->expectException(FileNotFoundException::class);
     $stencil->applyTemplate('notfound', []);
 });
 


### PR DESCRIPTION
This adds a fallback mechanism that can be set by adding additional template directories to Stencil, so when a template is not found at the expected location, Stencil will look for it inside the specified fallback directories.